### PR TITLE
Make graphical file dialog a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ keywords = [
 	"github-releases"
 ]
 
+[features]
+gui = ["rfd"]
+
 [dependencies]
 reqwest = { version = "0", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1", features = ["derive"] }
@@ -24,7 +27,8 @@ lazy_static = "1"
 serde_json = "1"
 semver = "1"
 home = "0"
-rfd = "0"
+rfd = { version = "0", optional = true }
+dialoguer = "0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -2,7 +2,7 @@ use crate::{launchermeta, HOME};
 use std::path::PathBuf;
 
 // macOS can only use a sync file picker
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "gui"))]
 #[allow(clippy::unused_async)] // We need the same function signature on all OSs
 /// Use the file picker to pick a file, defaulting to `path`
 pub async fn pick_folder(path: &PathBuf) -> Option<PathBuf> {
@@ -10,7 +10,7 @@ pub async fn pick_folder(path: &PathBuf) -> Option<PathBuf> {
 }
 
 // Other OSs can use the async version
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(target_os = "macos"), feature = "gui"))]
 /// Use the file picker to pick a file, defaulting to `path`
 pub async fn pick_folder(path: &PathBuf) -> Option<PathBuf> {
     rfd::AsyncFileDialog::new()
@@ -18,6 +18,17 @@ pub async fn pick_folder(path: &PathBuf) -> Option<PathBuf> {
         .pick_folder()
         .await
         .map(|handle| handle.path().into())
+}
+
+#[cfg(not(feature = "gui"))]
+pub async fn pick_folder(path: &PathBuf) -> Option<PathBuf> {
+    use dialoguer::{theme::ColorfulTheme, Input};
+
+    let res = Input::with_theme(&ColorfulTheme::default())
+        .default(path.to_str()?.to_string())
+        .interact()
+        .ok()?;
+    Some(res.into())
 }
 
 /// Get a maximum of `count` number of the latest versions of Minecraft from the `version_manifest` provided


### PR DESCRIPTION
This makes the graphical file dialog optional and hidden behind the `gui` feature.