### PR TITLE
Fix macOS application support directory

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -26,7 +26,7 @@ pub fn get_mods_dir() -> PathBuf {
     match std::env::consts::OS {
         "macos" => HOME
             .join("Library")
-            .join("ApplicationSupport")
+            .join("Application Support")
             .join("minecraft")
             .join("mods"),
         "linux" => HOME.join(".minecraft").join("mods"),


### PR DESCRIPTION
Closes https://github.com/theRookieCoder/ferium/issues/40

Testing if the existence of a space in the path breaks something is probably a good idea but I haven't done so.